### PR TITLE
Improve error descriptions of Optimizely API calls

### DIFF
--- a/optimizely/client/audience.go
+++ b/optimizely/client/audience.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 
 	"github.com/pffreitas/optimizely-terraform-provider/optimizely/audience"
 )
@@ -16,58 +14,26 @@ func (c OptimizelyClient) CreateAudience(aud audience.Audience) (audience.Audien
 		return aud, err
 	}
 
-	req, err := c.newHttpRequest("POST", "v2/audiences", bytes.NewBuffer(postBody))
-	if err != nil {
-		return aud, err
-	}
-
-	httpClient := http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return aud, err
-	}
-
-	if !c.isOk(resp.StatusCode) {
-		return audience.Audience{}, fmt.Errorf("failed to create audience in optimizely: %s", aud.Name)
-	}
-
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	respBody, err := c.sendHttpRequest("POST", "v2/audiences", bytes.NewBuffer(postBody))
 	if err != nil {
 		return aud, err
 	}
 
 	var audienceResp audience.Audience
-	json.Unmarshal(body, &audienceResp)
+	json.Unmarshal(respBody, &audienceResp)
 
 	return audienceResp, nil
 }
 
 func (c OptimizelyClient) GetAudience(audId string) (audience.Audience, error) {
 
-	req, err := c.newHttpRequest("GET", fmt.Sprintf("v2/audiences/%s", audId), nil)
-	if err != nil {
-		return audience.Audience{}, err
-	}
-
-	httpClient := http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return audience.Audience{}, err
-	}
-
-	if !c.isOk(resp.StatusCode) {
-		return audience.Audience{}, fmt.Errorf("failed to get audience from optimizely: %s", audId)
-	}
-
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	respBody, err := c.sendHttpRequest("GET", fmt.Sprintf("v2/audiences/%s", audId), nil)
 	if err != nil {
 		return audience.Audience{}, err
 	}
 
 	var audienceResp audience.Audience
-	json.Unmarshal(body, &audienceResp)
+	json.Unmarshal(respBody, &audienceResp)
 
 	return audienceResp, nil
 }
@@ -80,29 +46,13 @@ func (c OptimizelyClient) ArchiveAudience(audId string) (audience.Audience, erro
 		return audience.Audience{}, err
 	}
 
-	req, err := c.newHttpRequest("PATCH", fmt.Sprintf("v2/audiences/%s", audId), bytes.NewBuffer(postBody))
-	if err != nil {
-		return audience.Audience{}, err
-	}
-
-	httpClient := http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return audience.Audience{}, err
-	}
-
-	if !c.isOk(resp.StatusCode) {
-		return audience.Audience{}, fmt.Errorf("failed to archive audience in optimizely: %s", audId)
-	}
-
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	respBody, err := c.sendHttpRequest("PATCH", fmt.Sprintf("v2/audiences/%s", audId), bytes.NewBuffer(postBody))
 	if err != nil {
 		return audience.Audience{}, err
 	}
 
 	var audienceResp audience.Audience
-	json.Unmarshal(body, &audienceResp)
+	json.Unmarshal(respBody, &audienceResp)
 
 	return audienceResp, nil
 }
@@ -113,29 +63,13 @@ func (c OptimizelyClient) UpdateAudience(aud audience.Audience) (audience.Audien
 		return audience.Audience{}, err
 	}
 
-	req, err := c.newHttpRequest("PATCH", fmt.Sprintf("v2/audiences/%d", aud.ID), bytes.NewBuffer(postBody))
-	if err != nil {
-		return audience.Audience{}, err
-	}
-
-	httpClient := http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return audience.Audience{}, err
-	}
-
-	if !c.isOk(resp.StatusCode) {
-		return audience.Audience{}, fmt.Errorf("failed to update audience in optimizely: %s", aud.Name)
-	}
-
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	respBody, err := c.sendHttpRequest("PATCH", fmt.Sprintf("v2/audiences/%d", aud.ID), bytes.NewBuffer(postBody))
 	if err != nil {
 		return audience.Audience{}, err
 	}
 
 	var audienceResp audience.Audience
-	json.Unmarshal(body, &audienceResp)
+	json.Unmarshal(respBody, &audienceResp)
 
 	return audienceResp, nil
 }

--- a/optimizely/client/flags.go
+++ b/optimizely/client/flags.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 
 	"github.com/pffreitas/optimizely-terraform-provider/optimizely/flag"
 )
@@ -48,68 +46,30 @@ func (c OptimizelyClient) CreateFlag(feat flag.Flag) (flag.Flag, error) {
 		return feat, err
 	}
 
-	req, err := c.newHttpRequest("POST", fmt.Sprintf("flags/v1/projects/%d/flags", feat.ProjectId), bytes.NewBuffer(postBody))
-	if err != nil {
-		return feat, err
-	}
-
-	httpClient := http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return feat, err
-	}
-
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	respBody, err := c.sendHttpRequest("POST", fmt.Sprintf("flags/v1/projects/%d/flags", feat.ProjectId), bytes.NewBuffer(postBody))
 	if err != nil {
 		return feat, err
 	}
 
 	var featureResp flag.Flag
-	json.Unmarshal(body, &featureResp)
+	json.Unmarshal(respBody, &featureResp)
 
 	return featureResp, nil
 }
 
 func (c OptimizelyClient) GetFlag(projectId int, flagKey string) (flag.Flag, error) {
-	req, err := c.newHttpRequest("GET", fmt.Sprintf("flags/v1/projects/%d/flags/%s", projectId, flagKey), nil)
-	if err != nil {
-		return flag.Flag{}, err
-	}
-
-	httpClient := http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return flag.Flag{}, err
-	}
-
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	respBody, err := c.sendHttpRequest("GET", fmt.Sprintf("flags/v1/projects/%d/flags/%s", projectId, flagKey), nil)
 	if err != nil {
 		return flag.Flag{}, err
 	}
 
 	var flagResp flag.Flag
-	json.Unmarshal(body, &flagResp)
+	json.Unmarshal(respBody, &flagResp)
 
 	return flagResp, nil
 }
 
 func (c OptimizelyClient) DeleteFlag(projectId int, flagKey string) error {
-
-	req, err := c.newEmptyRequest("DELETE", fmt.Sprintf("flags/v1/projects/%d/flags/%s", projectId, flagKey))
-	if err != nil {
-		return err
-	}
-
-	httpClient := http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer resp.Body.Close()
-	_, err = ioutil.ReadAll(resp.Body)
-
+	_, err := c.sendHttpRequest("DELETE", fmt.Sprintf("flags/v1/projects/%d/flags/%s", projectId, flagKey), nil)
 	return err
 }

--- a/optimizely/client/ruleset.go
+++ b/optimizely/client/ruleset.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 
 	"github.com/pffreitas/optimizely-terraform-provider/optimizely/flag"
 )
@@ -91,23 +89,10 @@ func (c OptimizelyClient) CreateRuleset(flag flag.Flag) error {
 			return err
 		}
 
-		req, err := c.newHttpRequest("PATCH", fmt.Sprintf("flags/v1/projects/%d/flags/%s/environments/%s/ruleset", flag.ProjectId, flag.Key, env), bytes.NewBuffer(postBody))
+		_, err = c.sendHttpRequest("PATCH", fmt.Sprintf("flags/v1/projects/%d/flags/%s/environments/%s/ruleset", flag.ProjectId, flag.Key, env), bytes.NewBuffer(postBody))
 		if err != nil {
 			return err
 		}
-
-		httpClient := http.Client{}
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return err
-		}
-
-		defer resp.Body.Close()
-		_, err = ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-
 	}
 	return nil
 }
@@ -122,19 +107,7 @@ func (c OptimizelyClient) GetRuleset(flg flag.Flag) (map[string]flag.FeatureEnvi
 	for env := range flg.Environments {
 		flagEnv := flag.FeatureEnvironment{}
 
-		req, err := c.newEmptyRequest("GET", fmt.Sprintf("flags/v1/projects/%d/flags/%s/environments/%s/ruleset", flg.ProjectId, flg.Key, env))
-		if err != nil {
-			return flagEnvs, err
-		}
-
-		httpClient := http.Client{}
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return flagEnvs, err
-		}
-
-		defer resp.Body.Close()
-		rulesetResponseBodyStr, err := ioutil.ReadAll(resp.Body)
+		rulesetResponseBodyStr, err := c.sendHttpRequest("GET", fmt.Sprintf("flags/v1/projects/%d/flags/%s/environments/%s/ruleset", flg.ProjectId, flg.Key, env), nil)
 		if err != nil {
 			return flagEnvs, err
 		}
@@ -181,23 +154,10 @@ func (c OptimizelyClient) GetRuleset(flg flag.Flag) (map[string]flag.FeatureEnvi
 func (c OptimizelyClient) EnableRuleset(flag flag.Flag) error {
 
 	for env := range flag.Environments {
-		req, err := c.newEmptyRequest("POST", fmt.Sprintf("flags/v1/projects/%d/flags/%s/environments/%s/ruleset/enabled", flag.ProjectId, flag.Key, env))
+		_, err := c.sendHttpRequest("POST", fmt.Sprintf("flags/v1/projects/%d/flags/%s/environments/%s/ruleset/enabled", flag.ProjectId, flag.Key, env), nil)
 		if err != nil {
 			return err
 		}
-
-		httpClient := http.Client{}
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return err
-		}
-
-		defer resp.Body.Close()
-		_, err = ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-
 	}
 
 	return nil
@@ -206,23 +166,10 @@ func (c OptimizelyClient) EnableRuleset(flag flag.Flag) error {
 func (c OptimizelyClient) DisableRuleset(flag flag.Flag) error {
 
 	for env := range flag.Environments {
-		req, err := c.newEmptyRequest("POST", fmt.Sprintf("flags/v1/projects/%d/flags/%s/environments/%s/ruleset/disabled", flag.ProjectId, flag.Key, env))
+		_, err := c.sendHttpRequest("POST", fmt.Sprintf("flags/v1/projects/%d/flags/%s/environments/%s/ruleset/disabled", flag.ProjectId, flag.Key, env), nil)
 		if err != nil {
 			return err
 		}
-
-		httpClient := http.Client{}
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return err
-		}
-
-		defer resp.Body.Close()
-		_, err = ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-
 	}
 
 	return nil

--- a/optimizely/client/variation.go
+++ b/optimizely/client/variation.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 
 	"github.com/pffreitas/optimizely-terraform-provider/optimizely/flag"
 )
@@ -36,24 +34,8 @@ func (c OptimizelyClient) CreateVariation(flag flag.Flag, variation flag.Variati
 		return err
 	}
 
-	req, err := c.newHttpRequest("POST", fmt.Sprintf("flags/v1/projects/%d/flags/%s/variations", flag.ProjectId, flag.Key), bytes.NewBuffer(postBody))
-	if err != nil {
-		return err
-	}
-
-	httpClient := http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer resp.Body.Close()
-	_, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err = c.sendHttpRequest("POST", fmt.Sprintf("flags/v1/projects/%d/flags/%s/variations", flag.ProjectId, flag.Key), bytes.NewBuffer(postBody))
+	return err
 }
 
 type getVariationResponse struct {
@@ -62,25 +44,13 @@ type getVariationResponse struct {
 
 func (c OptimizelyClient) GetVariation(projectId int, flagKey string) ([]flag.Variation, error) {
 	var variations []flag.Variation
-	req, err := c.newHttpRequest("GET", fmt.Sprintf("flags/v1/projects/%d/flags/%s/variations", projectId, flagKey), nil)
-	if err != nil {
-		return variations, err
-	}
-
-	httpClient := http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return variations, err
-	}
-
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	respBody, err := c.sendHttpRequest("GET", fmt.Sprintf("flags/v1/projects/%d/flags/%s/variations", projectId, flagKey), nil)
 	if err != nil {
 		return variations, err
 	}
 
 	var getVariationResponse getVariationResponse
-	err = json.Unmarshal(body, &getVariationResponse)
+	err = json.Unmarshal(respBody, &getVariationResponse)
 	if err != nil {
 		return variations, err
 	}


### PR DESCRIPTION
This PR intends to make easier to identify and read the errors returned by Optimizely API.

Currently, most of the API requests are made on its own function and each one is handling errors differently. As we don't have a standard error handler for those requests, sometimes the Optimizely API errors are masked and it's difficult to realize what is behaving wrong. So the idea here is centralize all basic operations of HTTP calls to Optimizely in a way that avoids code repetition, standardize error messages, and keep the same functionallity already created.

The image below contains an example of error with the changes proposed by this PR.

![tf-optimizely-error](https://user-images.githubusercontent.com/4125170/152695618-966ec421-a4b0-47ed-81d5-011e8a02675b.png)
