### PR TITLE
Allow ruleset update in place (without recreating the whole resource).

### DIFF
--- a/optimizely/client/ruleset.go
+++ b/optimizely/client/ruleset.go
@@ -49,8 +49,7 @@ type OptimizelyRules struct {
 	RulePriorities []string            `json:"rule_priorities"`
 }
 
-func (c OptimizelyClient) CreateRuleset(flag flag.Flag) error {
-
+func (c OptimizelyClient) PatchRuleset(flag flag.Flag, operation Operation) error {
 	for env, flagEnv := range flag.Environments {
 		ops := []OptimizelyOp{}
 
@@ -71,13 +70,13 @@ func (c OptimizelyClient) CreateRuleset(flag flag.Flag) error {
 			}
 
 			ops = append(ops, OptimizelyOp{
-				Op:    "add",
+				Op:    operation,
 				Path:  fmt.Sprintf("/rules/%s", rule.Key),
 				Value: ruleset,
 			})
 
 			ops = append(ops, OptimizelyOp{
-				Op:    "add",
+				Op:    operation,
 				Path:  fmt.Sprintf("/rule_priorities/%d", i),
 				Value: rule.Key,
 			})
@@ -95,6 +94,14 @@ func (c OptimizelyClient) CreateRuleset(flag flag.Flag) error {
 		}
 	}
 	return nil
+}
+
+func (c OptimizelyClient) CreateRuleset(flag flag.Flag) error {
+	return c.PatchRuleset(flag, "add")
+}
+
+func (c OptimizelyClient) UpdateRuleset(flag flag.Flag) error {
+	return c.PatchRuleset(flag, "replace")
 }
 
 type getRulesetResponse struct {

--- a/optimizely/flag/client.go
+++ b/optimizely/flag/client.go
@@ -6,6 +6,7 @@ type FlagClient interface {
 	DeleteFlag(projectId int, flagKey string) error
 
 	CreateRuleset(flag Flag) error
+	UpdateRuleset(flag Flag) error
 	GetRuleset(flag Flag) (map[string]FeatureEnvironment, error)
 	EnableRuleset(flag Flag) error
 	DisableRuleset(flag Flag) error

--- a/optimizely/flag/resource_flag.go
+++ b/optimizely/flag/resource_flag.go
@@ -123,13 +123,11 @@ func ResourceFeature() *schema.Resource {
 			"rules": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"rule": {
 							Type:     schema.TypeList,
 							Required: true,
-							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {
@@ -140,7 +138,6 @@ func ResourceFeature() *schema.Resource {
 									"environments": {
 										Type:     schema.TypeList,
 										Required: true,
-										ForceNew: true,
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 										},
@@ -148,7 +145,6 @@ func ResourceFeature() *schema.Resource {
 									"audience": {
 										Type:     schema.TypeList,
 										Required: true,
-										ForceNew: true,
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 										},
@@ -156,12 +152,10 @@ func ResourceFeature() *schema.Resource {
 									"percentage_included": {
 										Type:     schema.TypeInt,
 										Required: true,
-										ForceNew: true,
 									},
 									"deliver": {
 										Type:     schema.TypeString,
 										Required: true,
-										ForceNew: true,
 									},
 								},
 							},
@@ -173,6 +167,7 @@ func ResourceFeature() *schema.Resource {
 		CreateContext: resourceFeatureCreate,
 		ReadContext:   resourceFeatureRead,
 		DeleteContext: resourceFeatureDelete,
+		UpdateContext: resourceFeatureUpdate,
 	}
 }
 
@@ -316,5 +311,35 @@ func resourceFeatureDelete(ctx context.Context, d *schema.ResourceData, m interf
 		return diags
 	}
 
+	return diags
+}
+
+func resourceFeatureUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	client := m.(FlagClient)
+
+	flag := parseFlag(d)
+
+	err := client.UpdateRuleset(flag)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Failed to create ruleset in Optimizely: %+v", err),
+		})
+
+		return diags
+	}
+
+	err = client.EnableRuleset(flag)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Failed to enable ruleset in Optimizely: %+v", err),
+		})
+
+		return diags
+	}
+
+	// return resourceFeatureRead(ctx, d, m)
 	return diags
 }


### PR DESCRIPTION
This PR introduces update functionality for rulesets allowing to apply updates without recreating the whole terraform resource.

This allows to progress with feature rollout without risk of having feature down in case recreating of the resource fails.

If that PR goes through I would like to submit another PR for a full scope update and read/import functionality so that provider can better recover from having state inconsistent with the service.