### PR TITLE
Correct the Go version and publishing metadata.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.18
       -
         name: Import GPG key
         id: import_gpg

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TEST?=$$(go list ./... | grep -v 'vendor')
-HOSTNAME=bees.io
-NAMESPACE=bees
+HOSTNAME=registry.terraform.io
+NAMESPACE=pffreitas
 NAME=optimizely
 BINARY=terraform-provider-${NAME}
 VERSION=0.10


### PR DESCRIPTION
This PR enables publishing binaries for windows/arm64 and darwin/arm64 (Mac with M1 CPU) which were skipped by goreleaser due to old version of Go:

```
      • DEPRECATED: skipped windows/arm64 build on Go < 1.17 for compatibility, check https://goreleaser.com/deprecations/#builds-for-windowsarm64 for more info.
      • DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check https://goreleaser.com/deprecations/#builds-for-darwinarm64 for more info.
```
See example: https://github.com/pffreitas/terraform-provider-optimizely/runs/5217048307?check_suite_focus=true

It also corrects the project metadata in Makefile.